### PR TITLE
Require Logger in Strava::Api::V3::Client

### DIFF
--- a/lib/strava/api/v3/client.rb
+++ b/lib/strava/api/v3/client.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'strava/api/v3/activity'
 require 'strava/api/v3/athlete'
 require 'strava/api/v3/club'


### PR DESCRIPTION
Pulled down the gem and started poking at it in irb, and after first requiring
it I got this:

```
irb(main):002:0> require 'strava/api/v3'
=> true
irb(main):003:0> @client = Strava::Api::V3::Client.new(:access_token => "blah")
NameError: uninitialized constant Strava::Api::V3::Client::Logger
        from /Users/jclark/source/strava-api-v3/lib/strava/api/v3/client.rb:35:in `initialize'
        from (irb):3:in `new'
        from (irb):3
        from /Users/jclark/.rbenv/versions/2.1.2/bin/irb:11:in `<main>'
        irb(main):004:0>
```

After that the gem was a breeze to use for accessing what I wanted off Strave.
Thanks so much for putting it out there! :heart: