### PR TITLE
added update_an_activity call

### DIFF
--- a/lib/strava/api/v3/activity.rb
+++ b/lib/strava/api/v3/activity.rb
@@ -73,5 +73,17 @@ module Strava::Api::V3
       # Fetches the connections for given object.
       api_call("activities/#{id}/laps", args, 'get', options, &block)
     end
+
+    # Updates an activity
+    # See {http://strava.github.io/api/v3/activities/#put-updates} for full details
+    #
+    # @param args any additional arguments
+    # @param options (see #get_object)
+    # @param block post processing code block
+    #
+    # @return updated activities json (see http://strava.github.io/api/v3/activities/)
+    def update_an_activity(id, args = {}, options = {}, &block)
+      api_call("activities/#{id}", args, 'put', options, &block)
+    end
   end
 end

--- a/lib/strava/api/v3/common.rb
+++ b/lib/strava/api/v3/common.rb
@@ -66,7 +66,7 @@ module Strava::Api::V3
       path = "/#{path}" unless path =~ /^\//
 
       # make the request via the provided service
-      result = HTTParty.get("#{Strava::Api::V3::Configuration::DEFAULT_ENDPOINT}#{path}", :query => args)
+      result = HTTParty.public_send(verb, "#{Strava::Api::V3::Configuration::DEFAULT_ENDPOINT}#{path}", :query => args)
 
       if result.code.to_i >= 500
         raise Strava::Api::V3::ServerError.new(result.code.to_i, result.body)


### PR DESCRIPTION
I've added the missing api call to update an activity.

I've also made use of the ``verb`` parameter in the ``api`` method :) 
Now, also post/put/delete requests can be issued.