### PR TITLE
Rename retrieve_race_details to retrieve_running_race_details

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Each method returns a JSON object - see [http://strava.github.io/api/v3/running_
 
 ```ruby
 
-@client.retrieve_race_details(:some_id)
+@client.retrieve_running_race_details(:race_id)
 
 @client.list_running_races
 

--- a/lib/strava/api/v3/running_race.rb
+++ b/lib/strava/api/v3/running_race.rb
@@ -14,7 +14,7 @@ module Strava::Api::V3
     # @param block post processing code block
     #
     # @return running race json (see http://strava.github.io/api/v3/running_races/)
-    def retrieve_race_details(id, args = {}, options = {}, &block)
+    def retrieve_running_race_details(id, args = {}, options = {}, &block)
       api_call("running_races/#{id}", args, 'get', options, &block)
     end
 


### PR DESCRIPTION
That was a quick merge! Thanks. @jaredholdcroft 

I realised it's probably more appropriate to name the API method to `retrieve_running_race_details` for consistency. What do you think? Up to you to decide I guess.